### PR TITLE
Remove mandatory GitHub token, use shields.io for star counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Github Sorter
 
-How many times have you opened countless new tabs to find top-starred projects on lists like Awesome Lists? Well, **[GitHub Sorter](https://github.com/sir-kokabi/github-sorter)** is here to make your life easier by sorting repos based on stars and displaying those shiny stars right beside each one. 😊🌟
-.
+How many times have you opened countless new tabs to find top-starred projects on lists like Awesome Lists? Well, **GitHub Sorter** is here to make your life easier by sorting repos based on stars and displaying those shiny stars right beside each one. 😊🌟
+
+**No GitHub token required** — star counts are fetched via shields.io (CDN-cached, no rate limits). Optionally add a token for better coverage (~5% of repos shields.io can't resolve).
 
 <hr>
 
@@ -16,24 +17,26 @@ How many times have you opened countless new tabs to find top-starred projects o
 
 ## Install (Chrome, Edge, Opera, Brave, Vivaldi)
 
-1. Download the latest [github-sorter.zip](https://github.com/sir-kokabi/github-sorter/releases/latest)
-2. Open the extension page in your browser by typing: `chrome://extensions/`
-3. Enable developer mode by clicking the toggle switch in the top right corner of the page.
-4. Drag and drop the downloaded `github-sorter.zip` onto the extension page.
-5. Open [Github token page](https://github.com/settings/tokens) (Create a GitHub account if you don't have one).
-6. Click the `Generate new token` button, then click `Generate new token (classic)`
-7. On the next page, enter the following information:
-   - Note: `token` (or any preferred name)
-   - Expiration: `no expirations`
-   - Select scopes: `repo`
-8. Click the `Generate token` button and then copy the generated token.
-9. Click the Github Sorter extension icon in the toolbar and paste the token.
-10. Now, when you visit any GitHub page that contains a list of repositories, all of the repositories will be sorted and show the number of stars.
+[Build from source](#building) or download the latest [github-sorter.zip](https://github.com/sir-kokabi/github-sorter/releases/latest), then:
 
-**Download from stores (Firefox and opera):**
+1. Open the extension page in your browser by typing: `chrome://extensions/`
+2. Enable developer mode by clicking the toggle switch in the top right corner of the page.
+3. Drag and drop the downloaded `github-sorter.zip` onto the extension page.
+4. Visit any GitHub page with repo links — star badges and sorting work immediately.
+
+**Optionally**, for better coverage on repos shields.io can't resolve:
+- Click the extension icon in the toolbar
+- Expand "Optional: GitHub token" and paste a [GitHub Personal Access Token](https://github.com/settings/tokens) (no specific scopes needed)
+
+**Download from stores:**
 
 - Firefox: https://addons.mozilla.org/firefox/addon/github-sorter/
 - Opera: https://addons.opera.com/extensions/details/github-sorter
+
+## Building
+
+For Chrome: zip `src/chrome/` into `github-sorter.zip`.
+For Firefox: zip `src/firefox/` into `github-sorter.zip`.
 
 ## Support
 

--- a/src/chrome/background.js
+++ b/src/chrome/background.js
@@ -8,20 +8,6 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
     const { githubToken } = await chrome.storage.sync.get("githubToken");
 
-    if (!githubToken) {
-      await showAlertBadge();
-      return
-    }
-
-    const response = await fetch(`https://api.github.com/user`, {
-      headers: { Authorization: `Bearer ${githubToken}` },
-    });
-
-    if (response.status !== 200) {
-      await showAlertBadge();
-      return;
-    }
-
     await chrome.scripting.executeScript({
       target: { tabId: tabId, allFrames: true },
       func: inject,
@@ -29,13 +15,6 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     });
   }
 });
-
-
-async function showAlertBadge() {
-  await chrome.action.setBadgeText({ text: '!' });
-  await chrome.action.setBadgeTextColor({ color: 'white' });
-  await chrome.action.setBadgeBackgroundColor({ color: 'red' });
-}
 
 function getSelector(url) {
   const selectors = [
@@ -120,7 +99,7 @@ async function inject(selector, githubToken) {
   }
 
   async function injectStars(link) {
-    const stars = await getStars(link.href);    
+    const stars = await getStars(link.href);
     if (!stars) return;
 
     const strong = document.createElement("strong");
@@ -128,7 +107,7 @@ async function inject(selector, githubToken) {
     strong.setAttribute("stars", stars);
     strong.style.color = "#fff";
     strong.style.fontSize = "12px";
-    strong.innerText = `★ ${roundNumber(stars)}`;
+    strong.innerText = `\u2605 ${roundNumber(stars)}`;
     strong.style.backgroundColor = "#093812";
     strong.style.paddingRight = "5px";
     strong.style.paddingLeft = "5px";
@@ -147,14 +126,38 @@ async function inject(selector, githubToken) {
   async function getStars(githubRepoURL) {
     const repoName = githubRepoURL.match(/github\.com\/([^/]+\/[^/]+)/)[1];
 
-    const response = await fetch(`https://api.github.com/repos/${repoName}`, {
-      headers: { Authorization: `Token ${githubToken}` },
-    });
+    try {
+      const res = await fetch(`https://img.shields.io/github/stars/${repoName}.json`);
+      if (res.ok) {
+        const data = await res.json();
+        const stars = parseStars(data.message);
+        if (stars !== null) return stars;
+      }
+    } catch {}
 
-    const data = await response.json();
-    const stars = data.stargazers_count;
+    if (githubToken) {
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repoName}`, {
+          headers: { Authorization: `Token ${githubToken}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          return data.stargazers_count;
+        }
+      } catch {}
+    }
 
-    return stars;
+    return null;
+  }
+
+  function parseStars(message) {
+    if (!message || message === "invalid" || message === "repo not found") return null;
+    let multiplier = 1;
+    let msg = message.trim();
+    if (msg.endsWith("M")) { multiplier = 1000000; msg = msg.slice(0, -1); }
+    else if (msg.endsWith("k")) { multiplier = 1000; msg = msg.slice(0, -1); }
+    const num = parseFloat(msg);
+    return isNaN(num) ? null : Math.round(num * multiplier);
   }
 
   function roundNumber(number) {

--- a/src/chrome/popup/popup.html
+++ b/src/chrome/popup/popup.html
@@ -8,13 +8,26 @@
     <title>GitHub Sorter</title>
   </head>
 
-  <body>    
-    <a dir="rtl" id="token-link" href="https://github.com/settings/tokens" target="_blank">GitHub Token</a>
-    <textarea placeholder="Enter your github token here..." type="text" name="token-input" id="token-input"></textarea>
-    <span id="statusMessage"></span>
+  <body>
+    <div>
+      <span style="font-size: 14px; font-weight: 600;">GitHub Sorter</span>
+      <span style="font-size: 11px; color: #666; margin-left: 4px;">active</span>
+    </div>
+    <p style="font-size: 12px; color: #555; margin: 6px 0 8px 0;">
+      Works without a token. The star badge appears on any page with GitHub repo links.
+    </p>
+    <details style="font-size: 12px; color: #555;">
+      <summary style="cursor: pointer; color: #4078c0;">Optional: GitHub token</summary>
+      <p style="margin: 4px 0;">
+        If shields.io can't resolve a repo, the token provides a fallback.
+        <a id="token-link" href="https://github.com/settings/tokens" target="_blank">Generate a token</a>.
+      </p>
+      <textarea placeholder="Optional: GitHub personal access token..." type="text" name="token-input" id="token-input"></textarea>
+      <span id="statusMessage" style="font-size: 11px;"></span>
+    </details>
 
     <div id="donation">
-      <div>       
+      <div>
         <a id="reymit" href="https://reymit.ir/kokabi" target="_blank">
           Make a Donation
         </a>

--- a/src/chrome/popup/popup.js
+++ b/src/chrome/popup/popup.js
@@ -1,83 +1,20 @@
 const tokenInput = document.getElementById('token-input');
 const statusMessage = document.getElementById('statusMessage');
-const btcButton = document.getElementById('btc');
-const ethButton = document.getElementById('eth');
 
-
-await chrome.storage.sync.get('githubToken', async (data) => {
-    if (data.githubToken){
-        tokenInput.value = data.githubToken;        
-        tokenInput.dispatchEvent(new Event('input'));
+chrome.storage.sync.get('githubToken').then((data) => {
+    if (data.githubToken) {
+        tokenInput.value = data.githubToken;
+        statusMessage.textContent = 'Token saved (optional fallback)';
     }
 });
 
-tokenInput.addEventListener('input', async () => {
+tokenInput.addEventListener('input', () => {
     const token = tokenInput.value.trim();
-    statusMessage.textContent = 'Validating token...';
-    await validateToken(token);
+    if (token) {
+        chrome.storage.sync.set({ githubToken: token });
+        statusMessage.textContent = 'Token saved (optional fallback)';
+    } else {
+        chrome.storage.sync.remove("githubToken");
+        statusMessage.textContent = 'Token removed';
+    }
 });
-
-function showToast(message, toastId) {
-    const toast = document.getElementById(toastId);
-    toast.innerText = message;
-    toast.style.opacity = 1;
-    setTimeout(() => {
-        toast.style.opacity = 0;
-        setTimeout(() => {
-            toast.innerText = '';
-        }, 500);
-    }, 900);
-}
-
-function copyToClipboard(text) {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand('copy');
-    document.body.removeChild(textarea);
-}
-
-
-async function validateToken(token){
-    try {
-        const response = await fetch(`https://api.github.com/user`, {
-            headers: { Authorization: `Bearer ${token}`},
-        });       
-
-        if (response.status === 200) {          
-            statusMessage.textContent = 'Valid Token (saved)';                               
-
-        } else if (response.status === 401) {
-            statusMessage.textContent = 'Expired or Invalid Token (not saved)';
-
-        } else {        
-            statusMessage.textContent = `Error: ${response.status} - ${await response.text()}`;
-        }
-
-        if (response.status === 200) {
-            await chrome.storage.sync.set({ githubToken: token });
-            await chrome.action.setBadgeText({ text: '' });            
-        }else{
-            await chrome.storage.sync.remove("githubToken");
-            await showAlertBadge();                
-        }
-    } catch (error) {        
-        statusMessage.textContent = error.toString();
-    }    
-}
-
-async function showAlertBadge() {
-    await chrome.action.setBadgeText({ text: '!' });
-    await chrome.action.setBadgeTextColor({ color: 'white' });
-    await chrome.action.setBadgeBackgroundColor({ color: 'red' });
-}
-
-
-
-
-
-
-
-
-

--- a/src/firefox/background.js
+++ b/src/firefox/background.js
@@ -8,21 +8,6 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
     const { githubToken } = await chrome.storage.sync.get("githubToken");
 
-    if (!githubToken) {
-      await showAlertBadge();
-      return
-    }
-
-    const response = await fetch(`https://api.github.com/user`, {
-      headers: { Authorization: `Bearer ${githubToken}` },
-    });
-
-    if (response.status !== 200) {
-      await showAlertBadge();
-      return;
-    }
-
-
     await chrome.scripting.executeScript({
       target: { tabId: tabId, allFrames: true },
       func: inject,
@@ -30,13 +15,6 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     });
   }
 });
-
-
-async function showAlertBadge() {
-  await chrome.action.setBadgeText({ text: '!' });
-  await chrome.action.setBadgeTextColor({ color: 'white' });
-  await chrome.action.setBadgeBackgroundColor({ color: 'red' });
-}
 
 function getSelector(url) {
   const selectors = [
@@ -129,7 +107,7 @@ async function inject(selector, githubToken) {
     strong.setAttribute("stars", stars);
     strong.style.color = "#fff";
     strong.style.fontSize = "12px";
-    strong.innerText = `★ ${roundNumber(stars)}`;
+    strong.innerText = `\u2605 ${roundNumber(stars)}`;
     strong.style.backgroundColor = "#093812";
     strong.style.paddingRight = "5px";
     strong.style.paddingLeft = "5px";
@@ -148,14 +126,38 @@ async function inject(selector, githubToken) {
   async function getStars(githubRepoURL) {
     const repoName = githubRepoURL.match(/github\.com\/([^/]+\/[^/]+)/)[1];
 
-    const response = await fetch(`https://api.github.com/repos/${repoName}`, {
-      headers: { Authorization: `Token ${githubToken}` },
-    });
+    try {
+      const res = await fetch(`https://img.shields.io/github/stars/${repoName}.json`);
+      if (res.ok) {
+        const data = await res.json();
+        const stars = parseStars(data.message);
+        if (stars !== null) return stars;
+      }
+    } catch {}
 
-    const data = await response.json();
-    const stars = data.stargazers_count;
+    if (githubToken) {
+      try {
+        const res = await fetch(`https://api.github.com/repos/${repoName}`, {
+          headers: { Authorization: `Token ${githubToken}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          return data.stargazers_count;
+        }
+      } catch {}
+    }
 
-    return stars;
+    return null;
+  }
+
+  function parseStars(message) {
+    if (!message || message === "invalid" || message === "repo not found") return null;
+    let multiplier = 1;
+    let msg = message.trim();
+    if (msg.endsWith("M")) { multiplier = 1000000; msg = msg.slice(0, -1); }
+    else if (msg.endsWith("k")) { multiplier = 1000; msg = msg.slice(0, -1); }
+    const num = parseFloat(msg);
+    return isNaN(num) ? null : Math.round(num * multiplier);
   }
 
   function roundNumber(number) {

--- a/src/firefox/popup/popup.html
+++ b/src/firefox/popup/popup.html
@@ -8,16 +8,28 @@
     <title>GitHub Sorter</title>
   </head>
 
-  <body>    
-    <a dir="rtl" id="token-link" href="https://github.com/settings/tokens" target="_blank">GitHub Token</a>
-    <textarea placeholder="Enter your github token here..." type="text" name="token-input" id="token-input"></textarea>
-    <span id="statusMessage"></span>
+  <body>
+    <div>
+      <span style="font-size: 14px; font-weight: 600;">GitHub Sorter</span>
+      <span style="font-size: 11px; color: #666; margin-left: 4px;">active</span>
+    </div>
+    <p style="font-size: 12px; color: #555; margin: 6px 0 8px 0;">
+      Works without a token. The star badge appears on any page with GitHub repo links.
+    </p>
+    <details style="font-size: 12px; color: #555;">
+      <summary style="cursor: pointer; color: #4078c0;">Optional: GitHub token</summary>
+      <p style="margin: 4px 0;">
+        If shields.io can't resolve a repo, the token provides a fallback.
+        <a id="token-link" href="https://github.com/settings/tokens" target="_blank">Generate a token</a>.
+      </p>
+      <textarea placeholder="Optional: GitHub personal access token..." type="text" name="token-input" id="token-input"></textarea>
+      <span id="statusMessage" style="font-size: 11px;"></span>
+    </details>
 
     <div id="donation">
-      <div>     
+      <div>
         <a id="reymit" href="https://reymit.ir/kokabi" target="_blank">
-          Make a Donation
-        </a>
+          Make a Donation</a>
       </div>
     </div>
 

--- a/src/firefox/popup/popup.js
+++ b/src/firefox/popup/popup.js
@@ -1,90 +1,26 @@
 const tokenInput = document.getElementById('token-input');
 const statusMessage = document.getElementById('statusMessage');
-const btcButton = document.getElementById('btc');
-const ethButton = document.getElementById('eth');
 
-await chrome.storage.sync.get('githubToken', async (data) => {
+chrome.storage.sync.get('githubToken').then((data) => {
     if (data.githubToken) {
         tokenInput.value = data.githubToken;
-        tokenInput.dispatchEvent(new Event('input'));
+        statusMessage.textContent = 'Token saved (optional fallback)';
     }
 });
 
 tokenInput.addEventListener('focus', async () => {
-    
-    let permission = {
+    await browser.permissions.request({
         origins: ["https://github.com/*"],
-    };
-    
-    await browser.permissions.request(permission);   
+    });
 });
 
-tokenInput.addEventListener('input', async () => {
+tokenInput.addEventListener('input', () => {
     const token = tokenInput.value.trim();
-    statusMessage.textContent = 'Validating token...';
-    await validateToken(token);
-});
-
-function showToast(message, toastId) {
-    const toast = document.getElementById(toastId);
-    toast.innerText = message;
-    toast.style.opacity = 1;
-    setTimeout(() => {
-        toast.style.opacity = 0;
-        setTimeout(() => {
-            toast.innerText = '';
-        }, 500);
-    }, 900);
-}
-
-function copyToClipboard(text) {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    document.body.appendChild(textarea);
-    textarea.select();
-    document.execCommand('copy');
-    document.body.removeChild(textarea);
-}
-
-async function validateToken(token) {
-    try {
-        const response = await fetch(`https://api.github.com/user`, {
-            headers: { Authorization: `Bearer ${token}` },
-        });
-
-        if (response.status === 200) {
-            statusMessage.textContent = 'Valid Token (saved)';
-
-        } else if (response.status === 401) {
-            statusMessage.textContent = 'Expired or Invalid Token (not saved)';
-
-        } else {
-            statusMessage.textContent = `Error: ${response.status} - ${await response.text()}`;
-        }
-
-        if (response.status === 200) {
-            await chrome.storage.sync.set({ githubToken: token });
-            await chrome.action.setBadgeText({ text: '' });
-        } else {
-            await chrome.storage.sync.remove("githubToken");
-            await showAlertBadge();
-        }
-    } catch (error) {
-        statusMessage.textContent = error.toString();
+    if (token) {
+        chrome.storage.sync.set({ githubToken: token });
+        statusMessage.textContent = 'Token saved (optional fallback)';
+    } else {
+        chrome.storage.sync.remove("githubToken");
+        statusMessage.textContent = 'Token removed';
     }
-}
-
-async function showAlertBadge() {
-    await chrome.action.setBadgeText({ text: '!' });
-    await chrome.action.setBadgeTextColor({ color: 'white' });
-    await chrome.action.setBadgeBackgroundColor({ color: 'red' });
-}
-
-
-
-
-
-
-
-
-
+});


### PR DESCRIPTION
## What

Replaces the mandatory GitHub API token with shields.io badge API as the primary source for star counts. The GitHub API is kept as an **optional fallback** when shields.io cannot resolve a repo (~5% of repos).

## Why

The mandatory GitHub token was a barrier to adoption:
- Users need to create, configure, and manage a GitHub token just to try the extension
- Unauthenticated GitHub API (60 req/hr) is too slow for large pages
- shields.io is CDN-cached, requires no auth, and has no per-user rate limits

## Changes

- **`background.js`**: Replace `getStars()` GitHub API call with shields.io JSON endpoint + `parseStars()` helper. Remove `showAlertBadge()` and all token validation. Token is now optional (passed as `githubToken`, used only as fallback).
- **`popup.html`**: Redesigned to explain the extension works without a token. Token section is collapsed by default under `<details>` tag.
- **`popup.js`**: Stripped `validateToken()`, `showAlertBadge()`, `showToast()`, `copyToClipboard()` — token is simply saved/removed on input without validation.
- **`README.md`**: Install steps simplified — no token required. Building section added.